### PR TITLE
fix N+1 query

### DIFF
--- a/kakeibo/views.py
+++ b/kakeibo/views.py
@@ -24,7 +24,7 @@ class KakeiboListView(LoginRequiredMixin, ListView):
 
     def get(self, request, *args, **kwargs):
         user = self.request.user
-        queryset = user.kakeibo_set.all()
+        queryset = user.kakeibo_set.select_related('category')
         context = {
             'kakeibo_list': queryset,
         }
@@ -89,7 +89,7 @@ class CircleChartView(LoginRequiredMixin, View):
     def get(self, request, *args, **kwargs):
         user = self.request.user
         first_date, last_date = self.get_month_first_and_last_date(timezone.now().year, timezone.now().month)
-        current_month_kakeibo_list = user.kakeibo_set.filter(category__balance_label=EXPENSE, date__range=(first_date, last_date)
+        current_month_kakeibo_list = user.kakeibo_set.select_related('category').filter(category__balance_label=EXPENSE, date__range=(first_date, last_date)
                                                             ).order_by('-date')
 
         total = sum([item.money for item in current_month_kakeibo_list])


### PR DESCRIPTION
N+1クエリになっていたので、select_relatedを使ってcategoryテーブルをjoinすることで対応した。
### before
![image](https://user-images.githubusercontent.com/43330646/66833532-f3725500-ef96-11e9-96a6-2115d5b9f831.png)

### after
![image](https://user-images.githubusercontent.com/43330646/66833611-1a308b80-ef97-11e9-9b97-1f6c33a2c1e7.png)

