### PR TITLE
[Update] Create without user_id

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -3,6 +3,8 @@ from accounts.models import CustomUser
 from rest_framework import generics
 from kakeibo.models import Kakeibo, Category
 from .serializers import KakeiboSerializer, CategorySerializer
+from rest_framework.response import Response
+from rest_framework import status
 
 
 class KakeiboListCreateView(generics.ListCreateAPIView):
@@ -28,9 +30,14 @@ class CategoryListCreateView(generics.ListCreateAPIView):
 
     def get_queryset(self):
         return Category.objects.filter(user=self.request.user)
-
-    def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+    
+    def create(self, request, *args, **kwargs):
+        data = request.data
+        data['user'] = request.user.id
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
 
 class CategoryRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):


### PR DESCRIPTION
カテゴリーを新規登録する際に、user_idを指定する必要がバグを修正した。
user_idを認証情報から取得するように変更した。