### PR TITLE
update pillow and delete pkg-resources

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,8 +6,7 @@ django-templated-mail==1.1.1
 djangorestframework==3.9.4
 djangorestframework-simplejwt==4.1.2
 djoser==1.7.0
-Pillow==6.0.0
-pkg-resources==0.0.0
+Pillow==6.2.1
 PyJWT==1.7.1
 pytz==2019.1
 sqlparse==0.3.0


### PR DESCRIPTION
githubからアップデートしろときていたので最新版にアップデート
pkg-resurcesはパッケージではないらしいので削除(https://codeday.me/jp/qa/20190116/156280.html)